### PR TITLE
Fix mobile mode operability except whack a mole

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -46,6 +46,7 @@ body {
     align-items: center;
     overflow: hidden;
     background: #e3f0ff;
+    touch-action: none;
 }
 .cell {
     width: 100%;
@@ -107,6 +108,7 @@ body {
     margin-right: auto;
     width: min(92vw, 480px);
     height: auto;
+    touch-action: none;
 }
 #plane-canvas {
     background: #f6faff;
@@ -118,6 +120,7 @@ body {
     margin-right: auto;
     width: min(92vw, 400px);
     height: auto;
+    touch-action: none;
 }
 #plane-controls {
     margin-bottom: 10px;
@@ -293,6 +296,7 @@ body {
     align-self: center; /* 在 #mole-section（flex 容器）中确保水平居中 */
     width: min(92vw, 400px);
     height: auto;
+    touch-action: none;
 }
 
 /* 响应式：iPad/手机（竖屏或窄屏）将侧栏变为顶部菜单 */

--- a/assets/js/plane.js
+++ b/assets/js/plane.js
@@ -250,4 +250,44 @@ window.addEventListener('keydown', function(e) {
         // 发射子弹
         bullets.push({x: plane.x + PLANE_WIDTH/2 - BULLET_WIDTH/2, y: plane.y - BULLET_HEIGHT});
     }
-}, { passive: false }); 
+}, { passive: false });
+
+// 移动端：在画布上拖动控制飞机位置，轻点发射子弹
+(function setupPlaneTouchControls() {
+    const canvas = document.getElementById('plane-canvas');
+    if (!canvas) return;
+    function toCanvasX(clientX) {
+        const rect = canvas.getBoundingClientRect();
+        const rel = (clientX - rect.left) / rect.width; // 0..1
+        return rel * PLANE_CANVAS_W;
+    }
+    let startX = 0, startY = 0, startTime = 0, maxMove = 0;
+    canvas.addEventListener('touchstart', function(e) {
+        if (document.getElementById('plane-section').style.display === 'none') return;
+        if (!e.touches || e.touches.length === 0) return;
+        const t = e.touches[0];
+        startX = t.clientX;
+        startY = t.clientY;
+        startTime = Date.now();
+        maxMove = 0;
+        const targetX = toCanvasX(t.clientX) - PLANE_WIDTH / 2;
+        plane.x = Math.max(0, Math.min(PLANE_CANVAS_W - PLANE_WIDTH, targetX));
+    }, { passive: true });
+    canvas.addEventListener('touchmove', function(e) {
+        if (document.getElementById('plane-section').style.display === 'none') return;
+        if (!e.touches || e.touches.length === 0) return;
+        const t = e.touches[0];
+        const dx = t.clientX - startX;
+        const dy = t.clientY - startY;
+        maxMove = Math.max(maxMove, Math.hypot(dx, dy));
+        const targetX = toCanvasX(t.clientX) - PLANE_WIDTH / 2;
+        plane.x = Math.max(0, Math.min(PLANE_CANVAS_W - PLANE_WIDTH, targetX));
+    }, { passive: true });
+    canvas.addEventListener('touchend', function(e) {
+        if (document.getElementById('plane-section').style.display === 'none') return;
+        const dt = Date.now() - startTime;
+        if (dt < 250 && maxMove < 12) {
+            bullets.push({x: plane.x + PLANE_WIDTH/2 - BULLET_WIDTH/2, y: plane.y - BULLET_HEIGHT});
+        }
+    }, { passive: true });
+})(); 

--- a/assets/js/snake.js
+++ b/assets/js/snake.js
@@ -259,3 +259,34 @@ window.addEventListener('keydown', function(e) {
 }, { passive: false });
 
 // 自动初始化（可在index.html的snake-section显示时调用initSnakeGame）
+
+// 移动端：在画布上支持滑动控制方向
+(function setupSnakeTouchControls() {
+    const canvas = document.getElementById('snake-canvas');
+    if (!canvas) return;
+    let startX = 0, startY = 0;
+    canvas.addEventListener('touchstart', function(e) {
+        if (document.getElementById('snake-section') && document.getElementById('snake-section').style.display === 'none') return;
+        if (!e.touches || e.touches.length === 0) return;
+        const t = e.touches[0];
+        startX = t.clientX;
+        startY = t.clientY;
+    }, { passive: true });
+    canvas.addEventListener('touchend', function(e) {
+        if (document.getElementById('snake-section') && document.getElementById('snake-section').style.display === 'none') return;
+        const t = e.changedTouches && e.changedTouches[0];
+        if (!t) return;
+        const dx = t.clientX - startX;
+        const dy = t.clientY - startY;
+        const absX = Math.abs(dx), absY = Math.abs(dy);
+        const threshold = 20; // 滑动阈值
+        if (absX < threshold && absY < threshold) return;
+        if (absX > absY) {
+            if (dx < 0 && direction !== 'right') nextDirection = 'left';
+            else if (dx > 0 && direction !== 'left') nextDirection = 'right';
+        } else {
+            if (dy < 0 && direction !== 'down') nextDirection = 'up';
+            else if (dy > 0 && direction !== 'up') nextDirection = 'down';
+        }
+    }, { passive: true });
+})();


### PR DESCRIPTION
Enable mobile play for Snake, Plane, and Minesweeper by adding touch controls and disabling default browser gestures on game canvases.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc8212da-a83e-47cc-95ae-90caad930a1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc8212da-a83e-47cc-95ae-90caad930a1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

